### PR TITLE
Update advanced-furnace.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.4.1
+Date: 27.08.2024
+  Bugfixes:
+    - Fixed issue causing crash when SE isn't loaded but the casting recipe option was set to true.
+---------------------------------------------------------------------------------------------------
 Version: 3.4.0
 Date: 10.08.2024
   Features:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Krastorio2RFAC",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"title": "Krastorio 2 Rocket Fuel in Advanced Chemical Plant",
 	"description": "Minor modification to allow advanced chemical plants to perform fuel refinement, atmospheric condensation, electrolysis, and filtration. Also added crushing recipes (sand and imersite powder) to advanced assembling machines. Requires Krastorio 2. Compatible with Space Exploration.",
 	"author": "PietersieliePC",

--- a/prototypes/entities/buildings/advanced-furnace.lua
+++ b/prototypes/entities/buildings/advanced-furnace.lua
@@ -1,5 +1,7 @@
 local K2RFACList = data.raw["assembling-machine"]["kr-advanced-furnace"].crafting_categories
 
-if (settings.startup["K2RFAC-bool-add-SE-casting-recipes-to-furnace-setting"].value) then
-	table.insert(K2RFACList, "casting")
+if (mods['space-exploration']) then
+	if (settings.startup["K2RFAC-bool-add-SE-casting-recipes-to-furnace-setting"].value) then
+		table.insert(K2RFACList, "casting")
+	end
 end


### PR DESCRIPTION
Fix a crash that occurs when only K2 is loaded, not SE as well.